### PR TITLE
Fix broken link to docker compose instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ You have three options:
     ```
 
     If you haven't got Docker Compose installed,
-    [follow these installation instructions](/compose/install/).
+    [follow these installation instructions](/compose/install.md).
 
     The container runs in the background and incrementally rebuilds the site each
     time a file changes. You can keep your browser open to http://localhost:4000/


### PR DESCRIPTION
The link to the Docker Compose install page is broken when viewing the README.md here on GitHub.

### Proposed changes

Fixed a broken link in the README.md to the Docker Compose install page. Unsure if it's meant to point to the .md file here or if it should point to the [docs page](https://docs.docker.com/compose/install/).